### PR TITLE
Adding docker functionality to allow for easy deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Emulated Roku image, takes Harmony control commands
+# and routes to configurable API endpoints
+#
+# Mount your own command handler to plugin into the 
+# API and set off custom commands by mounting your
+# own script to /server.py in the container.
+#
+# Image: notchristiangarcia/emulated_roku
+
+# Inherit from python3's alpine image (it's very small)
+from python:3-alpine
+
+# Update pip, install emulated_roku
+RUN pip3 install --upgrade pip
+
+# *_NO_EXTENSIONS variables needed to build yarl and
+# multidict on alpine linux, required for emulated_roku
+RUN YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install emulated-roku
+
+COPY example.py /server.py
+
+CMD ["python3", "-u", "/server.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN pip3 install --upgrade pip
 # multidict on alpine linux, required for emulated_roku
 RUN YARL_NO_EXTENSIONS=1 MULTIDICT_NO_EXTENSIONS=1 pip3 install emulated-roku
 
-COPY example.py /server.py
+COPY docker_server.py /server.py
 
 CMD ["python3", "-u", "/server.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,40 @@
-# emulated_roku
-
-This library is for emulating the Roku API. Discovery is tested with Logitech Harmony and Android remotes.
-Only key press / down / up events and app launches (10 dummy apps) are implemented in the RokuCommandHandler callback.  
+# emulated_roku  
+This library is for emulating the Roku API. Discovery is tested with Logitech Harmony and Android remotes.                                                                                                                                                                                                                                                                                  Only key press / down / up events and app launches (10 dummy apps) are implemented in the RokuCommandHandler callback.
 Other functionality such as input, search will not work.
 See the [example](example.py) on how to use.
+
+
+### Docker Integration and Deployment
+In this repository also lies a Dockerfile and docker-compose.yml file. The Docker image created by the Dockerfile
+allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have
+a volume mounted to overwrite that.
+
+#### Image creation
+Users are able to build and push the image to Dockerhub with the following commands.
+```
+docker build -t {username}/emulated_roku .
+docker push {username}/emulated_roku
+```
+
+#### Image usage
+Users are now able to use the local or remote emulated_roku image by doing the following.
+```
+docker run --net=host -v {custom_server.py file here}:/server.py {username}/emulated_roku
+```
+The `--net=host` flag allows for the docker container to use all of the host's networking prowess.  
+The `-v` flag allows users to specify their own `server.py` file rather than `example.py`.
+
+#### Docker-Compose
+The following is also an example of a `docker-compose.yml` that can be configured once and deployed with `docker-compose up -d`. With the `restart` field set to `unless-stopped`, the container will restart after computer shutdown or reboot unless explicitly stopped, allowing users to have an always on emulated_roku server.
+```
+---
+version: "3"
+services:
+  emulated_roku
+    image: {username}/emulated_roku
+    container_name: emulated_roku
+    network_mode: host
+    volumes:
+      - {your_server_file_path}.py:/server.py
+    restart: unless-stopped
+```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ See the [example](example.py) on how to use.
 
 
 ## Docker Integration and Deployment
-In this repository also lies a Dockerfile and docker-compose.yml file. The Docker image created by the Dockerfile
-allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have
-a volume mounted to read in another server file instead, for example `custom_command_handler_example.py`.
+In this repository also lies a Dockerfile file. The Docker image created by the Dockerfile allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have a volume mounted to read in another server file instead, for example `custom_command_handler_example.py`.
 
 #### Image creation
 Users are able to build and push the image to Dockerhub with the following commands.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Other functionality such as input, search will not work.
 See the [example](example.py) on how to use.
 
 
-### Docker Integration and Deployment
+## Docker Integration and Deployment
 In this repository also lies a Dockerfile and docker-compose.yml file. The Docker image created by the Dockerfile
 allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have
 a volume mounted to read in another server file instead, for example `custom_command_handler_example.py`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ See the [example](example.py) on how to use.
 ### Docker Integration and Deployment
 In this repository also lies a Dockerfile and docker-compose.yml file. The Docker image created by the Dockerfile
 allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have
-a volume mounted to overwrite that.
+a volume mounted to read in another server file instead, for example `custom_command_handler_example.py`.
 
 #### Image creation
 Users are able to build and push the image to Dockerhub with the following commands.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ See the [example](example.py) on how to use.
 
 
 ## Docker Integration and Deployment
-In this repository also lies a Dockerfile file. The Docker image created by the Dockerfile allows for running a user specified `server.py` file. The image defaults to `example.py` but the image can have a volume mounted to read in another server file instead, for example `custom_command_handler_example.py`.
+In this repository also lies a Dockerfile file. The Docker image created by the Dockerfile allows for running a user specified `server.py` file. The image defaults to `docker_server.py` but the image can have a volume mounted to read in another server file instead, for example `custom_server.py`.
 
 #### Image creation
 Users are able to build and push the image to Dockerhub with the following commands.
@@ -17,7 +17,7 @@ docker push {username}/emulated_roku
 #### Image usage
 Users are now able to use the local or remote emulated_roku image by doing the following.
 ```
-docker run --net=host -v {custom_server.py file here}:/server.py {username}/emulated_roku
+docker run --net=host -v {your custom_server.py file here}:/server.py {username}/emulated_roku
 ```
 The `--net=host` flag allows for the docker container to use all of the host's networking prowess.  
 The `-v` flag allows users to specify their own `server.py` file rather than `example.py`.

--- a/custom_command_handler_example.py
+++ b/custom_command_handler_example.py
@@ -1,0 +1,52 @@
+"""
+Script to run emulated_roku server and interpret Harmony
+controller inputs over wifi.
+"""
+import sys
+
+class myCustomCommandHandler():
+    """Base handler class for Roku commands."""
+    def on_keydown(self, roku_usn: str, key: str) -> None:
+        """Handle key down command."""
+        pass
+
+    def on_keyup(self, roku_usn: str, key: str) -> None:
+        """Handle key up command."""
+        pass
+
+    def on_keypress(self, roku_usn: str, key: str) -> None:
+        """Handle key press command."""
+        if key == "down":
+            print("task 1")
+        elif key == "info":
+            print("task 2")
+        pass
+
+    def launch(self, roku_usn: str, app_id: str) -> None:
+        """Handle launch command."""
+        pass
+
+
+if __name__ == "__main__":
+    import asyncio
+    import logging
+    import emulated_roku
+
+    logging.basicConfig(level=logging.DEBUG)
+
+    async def start_emulated_roku(loop):
+        roku_api = emulated_roku.EmulatedRokuServer(
+            loop,
+            myCustomCommandHandler(),
+            "test_roku",
+            emulated_roku.get_local_ip(),
+            8060)
+
+        await roku_api.start()
+
+
+    loop = asyncio.get_event_loop()
+
+    loop.run_until_complete(start_emulated_roku(loop))
+
+    loop.run_forever()

--- a/custom_command_handler_example.py
+++ b/custom_command_handler_example.py
@@ -16,9 +16,9 @@ class myCustomCommandHandler():
 
     def on_keypress(self, roku_usn: str, key: str) -> None:
         """Handle key press command."""
-        if key == "down":
+        if key == "Down":
             print("task 1")
-        elif key == "info":
+        elif key == "Info":
             print("task 2")
         pass
 

--- a/docker_server.py
+++ b/docker_server.py
@@ -1,6 +1,8 @@
 """
 Script to run emulated_roku server and interpret Harmony
 controller inputs over wifi.
+Includes a custom command handler that allows users to
+change outcomes of specific keypresses here.
 """
 import sys
 
@@ -17,9 +19,9 @@ class myCustomCommandHandler():
     def on_keypress(self, roku_usn: str, key: str) -> None:
         """Handle key press command."""
         if key == "Down":
-            print("task 1")
+            print("example task 1")
         elif key == "Info":
-            print("task 2")
+            print("example task 2")
         pass
 
     def launch(self, roku_usn: str, app_id: str) -> None:


### PR DESCRIPTION
Not sure if you want this, but I think it's incredibly useful for users. Basically allows users to deploy a Docker "container" that completely isolates the emulated_roku server and allows it to be easily updated, and ran with a simple command.

Along with that, with docker-compose users can have an always on server that automatically restarts when a computer runs. 

Useful for things like headless Raspberry Pi nodes (my use case).

You're able to host the image under your own account name, I left the files aliased with {username} for now. That means that people could just run `docker run mindigmarton/emulated_roku` and have a working server. (Though they would need the net and volume flags as mentioned in the expanded README.md)

I don't know. I think it's useful. Hope you do too. Just felt like helping!