### PR TITLE
Add support for custom applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ This library is for emulating the Roku API. Discovery is tested with Logitech Ha
 Only key press / down / up events and app launches (10 dummy apps) are implemented in the RokuCommandHandler callback.  
 Other functionality such as input, search will not work.
 See the [example](example.py) on how to use.
+
+Application list can be customized with a string in this format :
+
+`1:first-app,2:second-app,3:third-app`
+
+Which would generate this response :
+
+```angular2html
+<apps>
+    <app id="1" version="1.0.0">first-app</app>
+    <app id="2" version="1.0.0">second-app</app>
+    <app id="3" version="1.0.0">third-app</app>
+</apps>
+```

--- a/example.py
+++ b/example.py
@@ -12,7 +12,8 @@ if __name__ == "__main__":
     async def start_emulated_roku(loop):
         roku_api = emulated_roku.EmulatedRokuServer(
             loop, emulated_roku.EmulatedRokuCommandHandler(),
-            "test_roku", emulated_roku.get_local_ip(), 8060
+            "test_roku", emulated_roku.get_local_ip(), 8060,
+            custom_apps = None
         )
 
         await roku_api.start()


### PR DESCRIPTION
The emulated roku server can now support a list of custom applications by providing a coma/newline-separated list of application entries in the `id:name` format. The current 10 apps default value is returned when the value is None or does not contain any valid entries.

Example : 
`1:first-app,2:second-app,3:third-app`

or

```
1:first-app
2:second-app
3:third-app
```

generates
```
<apps>
   <app id="1" version="1.0.0">first-app</app>
   <app id="2" version="1.0.0">second-app</app>
   <app id="3" version="1.0.0">third-app</app>
</apps>
```

One use case would be to allow HomeAssistant to define it's on  custom apps. A smart remote control could detect it automatically and import the configured apps into its configuration.