### PR TITLE
Fix asyncio.get_event_loop() deprecation for Python 3.12+

### DIFF
--- a/advertise.py
+++ b/advertise.py
@@ -3,7 +3,7 @@
 if __name__ == "__main__":
     import logging
 
-    from asyncio import get_event_loop
+    import asyncio
     from argparse import ArgumentParser
     from os import name as osname
     import socket
@@ -54,7 +54,7 @@ if __name__ == "__main__":
             sock=sock)
 
 
-    loop = get_event_loop()
+    loop = asyncio.new_event_loop()
 
     loop.run_until_complete(start_emulated_roku(loop))
 

--- a/example.py
+++ b/example.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         await roku_api.start()
 
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
 
     loop.run_until_complete(start_emulated_roku(loop))
 


### PR DESCRIPTION
Hi! Thanks for this really useful library — it's been great for our Home Assistant setup with Harmony remotes.

## Summary

- Replace `asyncio.get_event_loop()` with `asyncio.new_event_loop()` in `advertise.py` and `example.py`

## Problem

`asyncio.get_event_loop()` was deprecated in Python 3.10 and emits a `DeprecationWarning`. Starting with Python 3.12, it raises a `RuntimeError` when called outside of an async context with no running event loop, breaking both scripts.

## Fix

Switched to `asyncio.new_event_loop()` which explicitly creates a new event loop — the correct pattern when you need to create and manage your own loop outside of `asyncio.run()`.

## Test plan

- [x] Verified `advertise.py` runs without deprecation warnings on Python 3.12+
- [x] Verified `example.py` runs without deprecation warnings on Python 3.12+
- [x] Confirmed no other files use the deprecated pattern